### PR TITLE
csscrittic.add expands array props

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,14 +21,31 @@ csscriticLib.main = function (regression, reporting, util, storage, selectionFil
         return testCase;
     };
 
-    module.add = function (testCase) {
-        var augmentedTestCase = util.clone(supportUrlAsOnlyTestCaseInput(testCase));
-
-        if (currentComponentLabel && augmentedTestCase.component === undefined) {
-            augmentedTestCase.component = currentComponentLabel;
+    var getFirstArrayProp = function(obj) {
+      for (var arrayKey in obj) {
+        if (obj[arrayKey] instanceof Array){
+          return arrayKey;
         }
+      }
+      return null;
+    }
 
-        testCases.push(augmentedTestCase);
+    module.add = function _add_recurs(testCase) {
+        var augmentedTestCase;
+        var arrayKey = getFirstArrayProp(testCase);
+        if (arrayKey) {
+          augmentedTestCase = util.clone(supportUrlAsOnlyTestCaseInput(testCase));
+          testCase[arrayKey].forEach(function(value){
+            augmentedTestCase[arrayKey] = value;
+            _add_recurs(augmentedTestCase);
+          });
+        } else {
+          augmentedTestCase = util.clone(supportUrlAsOnlyTestCaseInput(testCase));
+          if (currentComponentLabel && augmentedTestCase.component === undefined) {
+              augmentedTestCase.component = currentComponentLabel;
+          }
+          testCases.push(augmentedTestCase);
+        }
     };
 
 


### PR DESCRIPTION
If any property in the object passed to `add` is an array it will run the test for each value in the array.
When you want to run many similar tests this makes configuring them more concise / DRY.

e.g.:
```
   csscritic.add({ url: ['test-a.html','test-b.html']
                 , height: 200
                 , [320,640,800,1024,1280]
                 })
            .execute();
```